### PR TITLE
Refactor scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,37 @@
 
 `ds` is meant to be portable with a simple install process.
 
-### Recommended method
+### Recommended method (easy mode)
+
+*Requires Go 1.18+*
+```
+go install github.com/danielmichaels/ds/ds@latest
+```
+
+### Go Install doesn't work
+
+If the device does not have Go installed, or only has access to an older version, then
+you will need to use one of the following installation methods. It's just as easy but has
+some extra steps and requires you to manually select your operating system.
+
+**Curl the Binary**
+
+*Requires [jq](https://stedolan.github.io/jq/)*
+
+Running the following shell command will download the latest release to your current working directory. Once downloaded, you can run the
+binary with `./ds` or install it into your path as described in the next section.
+
+`OS=linux_x86 URL=$(curl api.github.com/repos/danielmichaels/ds/releases/latest -Ls | jq -r '.assets[].browser_download_url' | grep -i $OS) &&  curl -L -s $URL | tar xvz -C . ds`
+
+*Notes*: setting the `OS=` is important and must match your current operating system. The most common options are:
+
+- `linux_x86`
+- `linux_arm64`
+- `windows_x86`
+- `darwin_x86`
+- `darwin_arm64`
+
+**Browser Based Download**
 
 Go to the [releases](https://github.com/danielmichaels/ds/releases) page and 
 download the appropriate binary for your operating system.
@@ -15,12 +45,6 @@ For linux you can then drop the binary into your `PATH` or call the binary direc
 
 To drop it into your path simply copy the `ds` binary to `$HOME/.local/bin`. If that directory is 
 in your `$PATH` it will now be accessible by calling `ds` from your terminal.
-
-### Standalone
-
-```
-go install github.com/danielmichaels/ds/ds@latest
-```
 
 ## Usage
 
@@ -33,8 +57,28 @@ full command of `scripts`.
 
 Alias' can be identified in the `COMMANDS` list by the pipe operator such as `s|scripts`. 
 
+## Example Usage
+
+`ds` comes with many commands, some are local but others are imported from 
+other branches, or packages such as `y2j` and `yq`.
+
+**A few examples:**
+
 To get your current external IP address use `ds scripts ipify`, or its shorthand alias of `ds s ipify`.
 
+From your external IP address, print its IP information from [ipinfo.io] 
+using two `ds` commands together; 
+
+```shell
+ds scripts ipinfo $(ds scripts ip)
+```
+
+Parsing JSON or YAML by using `ds yq`.
+
+```shell
+echo '{"arr":{"index1":"one","index2":"two"},"nested":{"arr":{"indexArr1": {"idx":["one","two"]}}},"test":"string"}' | ds yq .arr                     
+# outputs: {"index1": "one", "index2": "two"}
+```
 
 ## Tab Completion
 
@@ -60,3 +104,4 @@ Example: `ds y2j help`
 * <https://github.com/rwxrob/bonzai-example> - a template to use when creating your own
 
 [rwxrob]: https://github.com/rwxrob
+[ipinfo.io]: https://ipinfo.io

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ using two `ds` commands together;
 ds scripts ipinfo $(ds scripts ip)
 ```
 
+Retrieving the current weather for a given location:
+
+```shell
+ds scripts weather london
+```
+
 Parsing JSON or YAML by using `ds yq`.
 
 ```shell

--- a/ds/main.go
+++ b/ds/main.go
@@ -29,7 +29,7 @@ func main() {
 var Cmd = &Z.Cmd{
 	Name:      `ds`,
 	Summary:   `*Do Something* is a single binary to rule them all`,
-	Version:   `v0.0.3`,
+	Version:   `v0.0.4`,
 	Copyright: `Copyright 2022 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Commands: []*Z.Cmd{

--- a/pkg/scripts/files/hugo
+++ b/pkg/scripts/files/hugo
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker run --rm -it -v "$HOME"/Code/github/danielms:/src -p 1313:1313  klakegg/hugo:latest "$@"

--- a/pkg/scripts/files/ipify
+++ b/pkg/scripts/files/ipify
@@ -1,2 +1,0 @@
-#!/bin/sh
-printf "%s\n" $(curl -s 'http://api.ipify.org?format=text')

--- a/pkg/scripts/scripts.go
+++ b/pkg/scripts/scripts.go
@@ -111,6 +111,7 @@ func fetch(urls []string) *http.Response {
 
 var ipcheck = &Z.Cmd{
 	Name:     `ip`,
+	Aliases:  []string{"ipify"},
 	Summary:  `print out the current external IP address`,
 	Commands: []*Z.Cmd{help.Cmd},
 	Call: func(caller *Z.Cmd, none ...string) error {

--- a/pkg/scripts/scripts.go
+++ b/pkg/scripts/scripts.go
@@ -4,12 +4,14 @@
 package scripts
 
 import (
+	"context"
 	"embed"
 	"errors"
 	"fmt"
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/help"
 	"github.com/rwxrob/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -58,34 +60,73 @@ func Retriever(filename string) (string, error) {
 }
 
 var Cmd = &Z.Cmd{
-	Name:     `scripts`,
-	Summary:  `call custom scripts`,
-	Aliases:  []string{"s"},
-	Commands: []*Z.Cmd{help.Cmd, weather, ipify, til, hugo, envCheck, ipinfo, pfsenseManager, epochDate},
+	Name:    `scripts`,
+	Summary: `call custom scripts`,
+	Aliases: []string{"s"},
+	Commands: []*Z.Cmd{
+		// imported commands
+		help.Cmd,
+		// local
+		weather, ipcheck, til, hugo, envCheck, ipinfo, pfsenseManager, epochDate,
+	},
 }
 
 var weather = &Z.Cmd{
 	Name:     `weather`,
-	Summary:  `the current weather for Canberra`,
+	Summary:  `the current weather for a given location, defaults to Canberra`,
 	Commands: []*Z.Cmd{help.Cmd},
-	Call: func(caller *Z.Cmd, none ...string) error {
-		return Z.Exec("curl", "v2.wttr.in/Canberra")
+	Call: func(caller *Z.Cmd, args ...string) error {
+		cmdlineArgs := strings.Join(args, " ")
+		if cmdlineArgs == "" {
+			cmdlineArgs = "Canberra"
+		}
+		return Z.Exec("curl", fmt.Sprintf("v2.wttr.in/%s", cmdlineArgs))
 	},
 }
 
-var ipify = &Z.Cmd{
-	Name:     `ipify`,
+// fetch will fire off multiple requests and return the first response whilst cancelling
+// the remaining in-flight requests.
+//
+//   res := fetch([]string{"https://a.com", "https://b.com"})
+func fetch(urls []string) *http.Response {
+	ch := make(chan *http.Response)
+	defer close(ch)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for _, url := range urls {
+		go func(ctx context.Context, url string) {
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			resp, err := http.DefaultClient.Do(req)
+			if err == nil {
+				//log.Println(resp.Request.URL)
+				select {
+				case ch <- resp:
+				case <-ctx.Done():
+				}
+			}
+		}(ctx, url)
+	}
+	return <-ch
+}
+
+var ipcheck = &Z.Cmd{
+	Name:     `ip`,
 	Summary:  `print out the current external IP address`,
 	Commands: []*Z.Cmd{help.Cmd},
 	Call: func(caller *Z.Cmd, none ...string) error {
-		script, err := Retriever("files/ipify")
+		urls := []string{
+			"https://api.ipify.org?format=text",
+			"https://trackip.net/ip",
+			"https://ipinfo.io/ip",
+		}
+		res := fetch(urls)
 
+		ip, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}
-		defer func() { _ = os.Remove(script) }()
-
-		return Z.Exec("sh", script)
+		fmt.Println(string(ip))
+		return nil
 	},
 }
 
@@ -94,15 +135,15 @@ var hugo = &Z.Cmd{
 	Summary:  `run the hugo docker image`,
 	Commands: []*Z.Cmd{help.Cmd},
 	Call: func(caller *Z.Cmd, args ...string) error {
-		cmdlineArgs := strings.Join(args, " ")
-
-		script, err := Retriever("files/hugo")
-		if err != nil {
-			return err
+		if os.Getenv("BLOG_PATH") == "" {
+			fmt.Println("BLOG_PATH not set. must point to the root directory for a hugo site")
+			Z.Exit()
 		}
-		defer func() { _ = os.Remove(script) }()
-
-		return Z.Exec("sh", script, cmdlineArgs)
+		cmdlineArgs := strings.Join(args, " ")
+		return Z.Exec(
+			"docker", "run", "--rm", "-it", "-v",
+			fmt.Sprintf("%s/%s:/src", os.Getenv("HOME"), os.Getenv("BLOG_PATH")),
+			"-p", "1313:1313", "klakegg/hugo", cmdlineArgs)
 	},
 }
 
@@ -139,39 +180,52 @@ var ipinfo = &Z.Cmd{
 			fmt.Println("must provide an IP address")
 			return caller.UsageError()
 		}
-		token := Z.Conf.Query(".ipinfo")
-		bearer := fmt.Sprintf("Bearer %s", token)
 
-		var result map[string]interface{}
-
-		cl := json.Client
-		cl.CheckRedirect = func(r *http.Request, via []*http.Request) error {
-			for k, v := range via[0].Header {
-				r.Header[k] = v
-			}
-			return nil
-		}
-		headers := map[string]string{}
-		headers["Authorization"] = bearer
-		req := json.Request{
-			Method: "GET",
-			URL:    fmt.Sprintf("https://ipinfo.io/%s", args[0]),
-			Query:  nil,
-			Header: headers,
-			Body:   nil,
-			Into:   &result,
-		}
-		err := json.Fetch(&req)
+		ip, err := queryIpinfo(args[0])
 		if err != nil {
 			return err
 		}
-		marshal, err := json.MarshalIndent(&result, " ", " ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(marshal))
+		fmt.Println(ip)
 		return nil
 	},
+}
+
+// queryIpinfo calls http://ipinfo.io and returns a json object with the IP data
+// about the IP address being queried. This function expects an `.ipinfo` value to be
+// present but will succeed with less information if not found.
+//   ip, err := queryIpinfo("1.1.1.1")
+func queryIpinfo(ip string) (string, error) {
+	token := Z.Conf.Query(".ipinfo")
+	bearer := fmt.Sprintf("Bearer %s", token)
+
+	var result map[string]interface{}
+
+	cl := json.Client
+	cl.CheckRedirect = func(r *http.Request, via []*http.Request) error {
+		for k, v := range via[0].Header {
+			r.Header[k] = v
+		}
+		return nil
+	}
+	headers := map[string]string{}
+	headers["Authorization"] = bearer
+	req := json.Request{
+		Method: "GET",
+		URL:    fmt.Sprintf("https://ipinfo.io/%s", ip),
+		Query:  nil,
+		Header: headers,
+		Body:   nil,
+		Into:   &result,
+	}
+	err := json.Fetch(&req)
+	if err != nil {
+		return "", err
+	}
+	marshal, err := json.MarshalIndent(&result, " ", " ")
+	if err != nil {
+		return "", err
+	}
+	return string(marshal), nil
 }
 
 var til = &Z.Cmd{


### PR DESCRIPTION
Two scripts have been removed and replaced with pure Go implementations; `hugo` and `ipify`.

**Changes**

- This has a name change, replacing `ipify` with `ip`. `ipify` is now an Alias of `ip` and will potentially be removed in the future.
- `weather` now takes arguments but will default to Canberra. `ds s weather london` will resolve London, UK whereas it was previously hardcoded to Canberra.
- `hugo` now expects an environment variable of `BLOG_PATH` to be present which must point to a valid Hugo root with a config file. 
- `ip|ipify` now uses three seperate external IP resolution services to ascertain the hosts eternal IP address. This *should* circumvent most DNS level blocking of such services.