### PR TITLE
Install application setup

### DIFF
--- a/ds/main.go
+++ b/ds/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"github.com/danielmichaels/ds/pkg/install"
 	"github.com/danielmichaels/ds/pkg/scripts"
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/config"
@@ -36,7 +37,7 @@ var Cmd = &Z.Cmd{
 		// imported
 		help.Cmd, config.Cmd, yq.Cmd, y2j.Cmd, vars.Cmd, uniq.Cmd,
 		// internal
-		scripts.Cmd,
+		scripts.Cmd, install.Cmd,
 	},
 	Issues: `github.com/danielmichaels/ds/issues`,
 	Site:   `danielms.site`,

--- a/ds/main.go
+++ b/ds/main.go
@@ -30,7 +30,7 @@ func main() {
 var Cmd = &Z.Cmd{
 	Name:      `ds`,
 	Summary:   `*Do Something* is a single binary to rule them all`,
-	Version:   `v0.0.4`,
+	Version:   `v0.0.5`,
 	Copyright: `Copyright 2022 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Commands: []*Z.Cmd{

--- a/pkg/install/curlie.go
+++ b/pkg/install/curlie.go
@@ -1,0 +1,37 @@
+package install
+
+import (
+	"fmt"
+	Z "github.com/rwxrob/bonzai/z"
+	"github.com/rwxrob/help"
+)
+
+var curlie = &Z.Cmd{
+	Name:     `curlie`,
+	Summary:  `install github.com/rs/curlie`,
+	Commands: []*Z.Cmd{help.Cmd},
+	Call: func(caller *Z.Cmd, args ...string) error {
+		if err := exeCheck("go"); err == nil {
+			err = goInstall("go", "github.com/rs/curlie@latest")
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := exeCheck("brew"); err == nil {
+			err = goInstall("brew", "github.com/rs/curlie@latest")
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := exeCheck("scoop"); err == nil {
+			err = goInstall("scoop", "github.com/rs/curlie@latest")
+			if err != nil {
+				return err
+			}
+		}
+		fmt.Println("curlie installed successfully")
+		return nil
+	},
+}

--- a/pkg/install/curlie.go
+++ b/pkg/install/curlie.go
@@ -8,8 +8,14 @@ import (
 )
 
 var curlie = &Z.Cmd{
-	Name:     `curlie`,
-	Summary:  `install github.com/rs/curlie`,
+	Name:    `curlie`,
+	Summary: `install github.com/rs/curlie`,
+	Description: `Installs *curlie* a drop-in replacement for cURL. It offers all the features
+			of curl but with *jq* output by default. 
+
+			The installer uses *brew* and Mac and *scoop* on Windows to install the application. Linux requires
+			Go to be installed. In future binary releases will be available making the need for Go to be
+			installed redundant.`,
 	Commands: []*Z.Cmd{help.Cmd},
 	Call: func(caller *Z.Cmd, args ...string) error {
 		var success = func() { fmt.Println("curlie successfully installed") }

--- a/pkg/install/curlie.go
+++ b/pkg/install/curlie.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/help"
+	"runtime"
 )
 
 var curlie = &Z.Cmd{
@@ -11,27 +12,45 @@ var curlie = &Z.Cmd{
 	Summary:  `install github.com/rs/curlie`,
 	Commands: []*Z.Cmd{help.Cmd},
 	Call: func(caller *Z.Cmd, args ...string) error {
-		if err := exeCheck("go"); err == nil {
-			err = goInstall("go", "github.com/rs/curlie@latest")
-			if err != nil {
-				return err
+		var success = func() { fmt.Println("curlie successfully installed") }
+		switch runtime.GOOS {
+		case "darwin":
+			if err := exeCheck("brew"); err == nil {
+				err = goInstall("brew", "rs/tap/curlie")
+				if err != nil {
+					return err
+				}
+				success()
+				return nil
+			}
+		case "windows":
+			if err := exeCheck("scoop"); err == nil {
+				err = goInstall("scoop", "curlie")
+				if err != nil {
+					return err
+				}
+				success()
+				return nil
+			}
+		case "linux":
+			if err := exeCheck("go"); err == nil {
+				err = goInstall("go", "github.com/rs/curlie@latest")
+				if err != nil {
+					return err
+				}
+				success()
+				return nil
+			}
+		default:
+			if err := exeCheck("go"); err == nil {
+				err = goInstall("go", "github.com/rs/curlie@latest")
+				if err != nil {
+					return err
+				}
+				success()
+				return nil
 			}
 		}
-
-		if err := exeCheck("brew"); err == nil {
-			err = goInstall("brew", "github.com/rs/curlie@latest")
-			if err != nil {
-				return err
-			}
-		}
-
-		if err := exeCheck("scoop"); err == nil {
-			err = goInstall("scoop", "github.com/rs/curlie@latest")
-			if err != nil {
-				return err
-			}
-		}
-		fmt.Println("curlie installed successfully")
 		return nil
 	},
 }

--- a/pkg/install/gh.go
+++ b/pkg/install/gh.go
@@ -1,0 +1,82 @@
+package install
+
+import (
+	"fmt"
+	"github.com/danielmichaels/ds/pkg/scripts"
+	Z "github.com/rwxrob/bonzai/z"
+	"github.com/rwxrob/help"
+	"os"
+	"runtime"
+	"strings"
+)
+
+var gh = &Z.Cmd{
+	Name:     `gh`,
+	Summary:  `install github.com/cli/cli`,
+	Commands: []*Z.Cmd{help.Cmd},
+	Call: func(caller *Z.Cmd, args ...string) error {
+		var success = func() { fmt.Println("gh successfully installed") }
+		switch runtime.GOOS {
+		case "darwin":
+			if err := exeCheck("brew"); err == nil {
+				// todo add upgrade option
+				err = goInstall("brew", "gh")
+				if err != nil {
+					return err
+				}
+				success()
+				return nil
+			}
+		case "windows":
+			if err := exeCheck("scoop"); err == nil {
+				err = goInstall("scoop", "gh")
+				if err != nil {
+					return err
+				}
+				success()
+				return nil
+			}
+		case "linux":
+			var s string
+			fmt.Printf("options: 1. ubuntu/debian/rpi 2. centos/rhel/fedora\nEnter a number: ")
+			_, err := fmt.Scanln(&s)
+			if err != nil {
+				return err
+			}
+
+			s = strings.TrimSpace(s)
+			s = strings.ToLower(s)
+
+			println(s)
+			switch s {
+			case "1":
+				script, err := scripts.Retriever("files/gh-ubuntu")
+				if err != nil {
+					return err
+				}
+				defer func() { _ = os.Remove(script) }()
+				return Z.Exec("bash", script)
+			case "2":
+				script, err := scripts.Retriever("files/gh-centos")
+				if err != nil {
+					return err
+				}
+				defer func() { _ = os.Remove(script) }()
+				return Z.Exec("bash", script)
+			default:
+				fmt.Println("did not supply a valid option - if your os is not available please raise an issue")
+				return err
+			}
+		default:
+			if err := exeCheck("go"); err == nil {
+				err = goInstall("go", "github.com/rs/curlie@latest")
+				if err != nil {
+					return err
+				}
+				success()
+				return nil
+			}
+		}
+		return nil
+	},
+}

--- a/pkg/install/gh.go
+++ b/pkg/install/gh.go
@@ -11,8 +11,11 @@ import (
 )
 
 var gh = &Z.Cmd{
-	Name:     `gh`,
-	Summary:  `install github.com/cli/cli`,
+	Name:    `gh`,
+	Summary: `install github.com/cli/cli`,
+	Description: `Installs github's cli *gh* and supports mac, windows and linux. Only Centos and 
+		Debian-based linux derivatives are supported. Mac and windows rely upon *brew* and *scoop*
+		respectively. No binary installations are supported as yet. Linux requires sudo privileges.`,
 	Commands: []*Z.Cmd{help.Cmd},
 	Call: func(caller *Z.Cmd, args ...string) error {
 		var success = func() { fmt.Println("gh successfully installed") }

--- a/pkg/install/gh.go
+++ b/pkg/install/gh.go
@@ -50,7 +50,6 @@ var gh = &Z.Cmd{
 			s = strings.TrimSpace(s)
 			s = strings.ToLower(s)
 
-			println(s)
 			switch s {
 			case "1":
 				script, err := scripts.Retriever("files/gh-ubuntu")

--- a/pkg/install/go.go
+++ b/pkg/install/go.go
@@ -1,0 +1,59 @@
+package install
+
+import (
+	"fmt"
+	"github.com/danielmichaels/ds/pkg/scripts"
+	Z "github.com/rwxrob/bonzai/z"
+	"github.com/rwxrob/help"
+	"os"
+	"runtime"
+	"strings"
+)
+
+var goLinux = &Z.Cmd{
+	Name:    `go`,
+	Summary: `install the latest Go version onto a linux system`,
+	Description: `This will install the latest Go version on to the host system.
+
+		**Must be linux/amd64.**`,
+	Commands: []*Z.Cmd{help.Cmd},
+	Call: func(caller *Z.Cmd, args ...string) error {
+		switch runtime.GOOS {
+		case "linux":
+			err := installGo()
+			if err != nil {
+				return err
+			}
+		default:
+			fmt.Printf("Operating system: %s\n", runtime.GOOS)
+			fmt.Println("Did not detect a linux operating system. Exiting")
+			Z.Exit()
+		}
+		return nil
+	},
+}
+
+func installGo() error {
+	var s string
+	fmt.Printf("Install Go 1.18 onto the system? y/N ")
+	_, err := fmt.Scanln(&s)
+	if err != nil {
+		return err
+	}
+
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+
+	switch s {
+	case "y":
+		script, err := scripts.Retriever("files/go-linux")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = os.Remove(script) }()
+		return Z.Exec("bash", script)
+	default:
+		fmt.Println("Did not select 'y'. Aborting install.")
+		return err
+	}
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -10,7 +10,7 @@ var Cmd = &Z.Cmd{
 	Name:        `install`,
 	Summary:     `install executables and applications onto the host system`,
 	Description: `Commands under this branch are used to install common executables and applications on the host system.`,
-	Other:       []Z.Section{{`Application Options`, `curlie`}},
+	Other:       []Z.Section{{`Application Options`, `curlie, gh`}},
 	Commands: []*Z.Cmd{
 		// imported commands
 		help.Cmd,

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -1,0 +1,35 @@
+package install
+
+import (
+	Z "github.com/rwxrob/bonzai/z"
+	"github.com/rwxrob/help"
+	"os/exec"
+)
+
+var Cmd = &Z.Cmd{
+	Name:        `install`,
+	Summary:     `install executables and applications onto the host system`,
+	Description: `Commands under this branch are used to install common executables and applications on the host system.`,
+	Other:       []Z.Section{{`Application Options`, `curlie`}},
+	Commands: []*Z.Cmd{
+		// imported commands
+		help.Cmd,
+		// local
+		curlie,
+	},
+}
+
+func exeCheck(exe string) error {
+	_, err := exec.LookPath(exe)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func goInstall(exe, pkg string) error {
+	err := Z.Exec(exe, "install", pkg)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -10,12 +10,12 @@ var Cmd = &Z.Cmd{
 	Name:        `install`,
 	Summary:     `install executables and applications onto the host system`,
 	Description: `Commands under this branch are used to install common executables and applications on the host system.`,
-	Other:       []Z.Section{{`Application Options`, `curlie, gh`}},
+	Other:       []Z.Section{{`Application Options`, `curlie, gh, go`}},
 	Commands: []*Z.Cmd{
 		// imported commands
 		help.Cmd,
 		// local
-		curlie, gh,
+		curlie, gh, goLinux,
 	},
 }
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -15,7 +15,7 @@ var Cmd = &Z.Cmd{
 		// imported commands
 		help.Cmd,
 		// local
-		curlie,
+		curlie, gh,
 	},
 }
 

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -1,0 +1,41 @@
+package install
+
+import (
+	"testing"
+)
+
+func TestGoCheck(t *testing.T) {
+	tt := []struct {
+		name string
+		exe  string
+		want string
+	}{
+		{
+			name: "ls executable available",
+			exe:  "ls",
+			want: "",
+		},
+		{
+			name: "go executable available",
+			exe:  "go",
+			want: "",
+		},
+		{
+			name: "executable unavailable errors",
+			exe:  "bad123",
+			want: `exec: "bad123": executable file not found in $PATH`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := exeCheck(tc.exe)
+			if err != nil {
+				if err.Error() != tc.want {
+					t.Fatalf("test %s failed.\ngot:  %#v\nwant: %#v", tc.name, err.Error(), tc.want)
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/scripts/files/gh-centos
+++ b/pkg/scripts/files/gh-centos
@@ -1,0 +1,4 @@
+#!/bin/sh
+sudo dnf install 'dnf-command(config-manager)'
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf install gh

--- a/pkg/scripts/files/gh-ubuntu
+++ b/pkg/scripts/files/gh-ubuntu
@@ -1,0 +1,5 @@
+#!/bin/sh
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install gh

--- a/pkg/scripts/files/go-linux
+++ b/pkg/scripts/files/go-linux
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+install_go() {
+  cd "$(mktemp -d)"
+
+  os=linux
+  arch=amd64
+
+  file=$(curl -SL  "https://golang.org/dl/?mode=json" \
+    | jq -r '.[0].files[]
+      | select(.os == "'"$os"'")
+      | select(.arch == "'"$arch"'")
+      | .filename')
+
+  curl -sSLO \
+    -H "Accept: application/vnd.github.v3+json" \
+     "https://dl.google.com/go/$file"
+
+  sudo tar xzf "$file" -C /usr/local/
+
+  echo "Make sure /usr/local/go/bin is in PATH"
+}
+
+install_go


### PR DESCRIPTION
This PR adds installers for `curlie` and `gh`.

For this first pass both applications use package managers or `go install`. This limits the true portability of `ds` but is a first step and will be workable for most of my needs. A binary install option is required for systems which do not have `go` installed locally.