### PR TITLE
Add `zet-cmd`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-  - main: ./ds
+  - main: ./cmd/ds
     env:
       - CGO_ENABLED=0
     goos:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## Install
 
-`ds` is meant to be portable with a simple install process.
+`ds` is meant to be portable with a simple installation process.
 
 ### Recommended method (easy mode)
 
 *Requires Go 1.18+*
 ```
-go install github.com/danielmichaels/ds/ds@latest
+go install github.com/danielmichaels/cmd/ds@latest
 ```
 
 ### Go Install doesn't work

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"github.com/danielmichaels/ds/pkg/install"
 	"github.com/danielmichaels/ds/pkg/scripts"
+	"github.com/danielmichaels/zet-cmd"
 	Z "github.com/rwxrob/bonzai/z"
 	"github.com/rwxrob/compfile"
 	"github.com/rwxrob/conf"
@@ -24,7 +25,7 @@ func main() {
 var Cmd = &Z.Cmd{
 	Name:      `ds`,
 	Summary:   `*Do Something* is a single binary to rule them all`,
-	Version:   `v0.1.1`,
+	Version:   `v0.1.2`,
 	Copyright: `Copyright 2022 Daniel Michaels`,
 	License:   `Apache-2.0`,
 	Comp:      compfile.New(),
@@ -35,7 +36,7 @@ var Cmd = &Z.Cmd{
 	},
 	Commands: []*Z.Cmd{
 		// imported
-		help.Cmd, conf.Cmd, yq.Cmd, vars.Cmd, y2j.Cmd, vars.Cmd, uniq.Cmd,
+		help.Cmd, conf.Cmd, yq.Cmd, vars.Cmd, y2j.Cmd, vars.Cmd, uniq.Cmd, zet.Cmd,
 		// internal
 		scripts.Cmd, install.Cmd,
 	},

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 
 require (
 	github.com/a8m/envsubst v1.3.0 // indirect
-	github.com/danielmichaels/zet-cmd v0.0.2 // indirect
+	github.com/danielmichaels/zet-cmd v0.0.3 // indirect
 	github.com/elliotchance/orderedmap v1.4.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/goccy/go-yaml v1.9.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 
 require (
 	github.com/a8m/envsubst v1.3.0 // indirect
+	github.com/danielmichaels/zet-cmd v0.0.2 // indirect
 	github.com/elliotchance/orderedmap v1.4.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/goccy/go-yaml v1.9.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/danielmichaels/ds
 go 1.18
 
 require (
+	github.com/danielmichaels/zet-cmd v0.0.3
 	github.com/rwxrob/bonzai v0.12.2
 	github.com/rwxrob/compfile v0.1.10
 	github.com/rwxrob/conf v0.6.3
@@ -16,7 +17,6 @@ require (
 
 require (
 	github.com/a8m/envsubst v1.3.0 // indirect
-	github.com/danielmichaels/zet-cmd v0.0.3 // indirect
 	github.com/elliotchance/orderedmap v1.4.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/goccy/go-yaml v1.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
 github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
+github.com/danielmichaels/zet-cmd v0.0.1 h1:ufNhH4dzKS636tXFkWa4/2WT8d/ANUPBHnolSFfugww=
+github.com/danielmichaels/zet-cmd v0.0.1/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
+github.com/danielmichaels/zet-cmd v0.0.2 h1:aBM+wfWslk6sBTMrDTTlWufA6yvPGuI5TsYJ/e0ag38=
+github.com/danielmichaels/zet-cmd v0.0.2/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elliotchance/orderedmap v1.4.0 h1:wZtfeEONCbx6in1CZyE6bELEt/vFayMvsxqI5SgsR+A=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
 github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
-github.com/danielmichaels/zet-cmd v0.0.1 h1:ufNhH4dzKS636tXFkWa4/2WT8d/ANUPBHnolSFfugww=
-github.com/danielmichaels/zet-cmd v0.0.1/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
-github.com/danielmichaels/zet-cmd v0.0.2 h1:aBM+wfWslk6sBTMrDTTlWufA6yvPGuI5TsYJ/e0ag38=
-github.com/danielmichaels/zet-cmd v0.0.2/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
 github.com/danielmichaels/zet-cmd v0.0.3 h1:RO/5VM9fxqhARPMbUrhP5DDacAqXHGJx+eVTjAnaT/c=
 github.com/danielmichaels/zet-cmd v0.0.3/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/danielmichaels/zet-cmd v0.0.1 h1:ufNhH4dzKS636tXFkWa4/2WT8d/ANUPBHnol
 github.com/danielmichaels/zet-cmd v0.0.1/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
 github.com/danielmichaels/zet-cmd v0.0.2 h1:aBM+wfWslk6sBTMrDTTlWufA6yvPGuI5TsYJ/e0ag38=
 github.com/danielmichaels/zet-cmd v0.0.2/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
+github.com/danielmichaels/zet-cmd v0.0.3 h1:RO/5VM9fxqhARPMbUrhP5DDacAqXHGJx+eVTjAnaT/c=
+github.com/danielmichaels/zet-cmd v0.0.3/go.mod h1:2CRp1HLyUg210C4UHazCrpB2T+HMpf2ACqmHw57DPUo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elliotchance/orderedmap v1.4.0 h1:wZtfeEONCbx6in1CZyE6bELEt/vFayMvsxqI5SgsR+A=

--- a/pkg/scripts/scripts.go
+++ b/pkg/scripts/scripts.go
@@ -95,7 +95,7 @@ func fetch(urls []string) *http.Response {
 	defer cancel()
 	for _, url := range urls {
 		go func(ctx context.Context, url string) {
-			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 			resp, err := http.DefaultClient.Do(req)
 			if err == nil {
 				//log.Println(resp.Request.URL)


### PR DESCRIPTION
`ds` now includes its first Bonzai module written by me.

`ds zet` will now have access [zet-cmd](https://github.com/danielmichaels/zet-cmd). This has been added to make `zet-cmd` portable within `ds`.

The directory path for `main.go` has changed. The README has been updated to reflect the new install path. 

This also fixes a context.WithCancel issue. See this [commit](https://github.com/danielmichaels/ds/pull/13/commits/7d80f94d8f5fe624edd12d2e1dece10a826c57ec)